### PR TITLE
[WIP] Split body texts into smaller documents

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,24 +39,27 @@ module.exports = {
             }
 
             this.log.debug.ln('index page', page.path);
-            // Transform as text
-            const text = page.content.replace(/(<([^>]+)>)/ig, '');
-
+            const url = this.output.toURL(page.path);
             let keywords = [];
             if (searchConfig) {
                 keywords = searchConfig.keywords || [];
             }
-
-            // Add to index
-            return index.addObject({
-                url:   this.output.toURL(page.path),
+            // Transform as paragraphs
+            const text = page.content.replace(/(<([^>]+)>)/ig, '');
+            const lines = text.split(/\r\n|\n|\r/);
+            const lineObjects = lines.map(line => ({
+                url,
                 path:  page.path,
                 title: page.title,
                 keywords,
-                body:  text,
+                body:  line,
                 level: page.level,
                 depth: page.depth
-            })
+              })
+            );
+
+            // Add to index
+            return index.addObjects(lineObjects)
             .then(function() {
                 return page;
             });


### PR DESCRIPTION
# What this resolves
- Increase latency
- Avoid “Record is too big” error


# Proposed change
Instead of having a body text for each page, split them into paragraphs.


# Emerging issue
This doesn't work properly when searching with page attributes like page.title, page.path.


# Reference
- [Distinct to Index Large Records](https://www.algolia.com/doc/guides/ranking/distinct/?language=javascript#distinct-to-index-large-records) algolia guides
- [Add objects](https://www.algolia.com/doc/api-reference/api-methods/add-objects/?language=javascript#add-objects) algolia API method


# Relevant issue
#10